### PR TITLE
PID File should not be in /tmp

### DIFF
--- a/scripts/newrhelic
+++ b/scripts/newrhelic
@@ -38,7 +38,7 @@ class RunApp:
         self.stdin_path = '/dev/null'
         self.stdout_path = '/dev/tty'
         self.stderr_path = '/dev/tty'
-        self.pidfile_path =  '/tmp/newrhelic.pid'
+        self.pidfile_path =  '/var/run/newrhelic.pid'
         self.pidfile_timeout = 5
 
     def run(self):

--- a/scripts/newrhelic-plugin
+++ b/scripts/newrhelic-plugin
@@ -7,7 +7,7 @@
 #
 # processname: newrhelic
 # config: /etc/newrhelic.conf
-# pidfile: /tmp/newrhelic.pid
+# pidfile: /var/run/newrhelic.pid
 
 /usr/bin/newrhelic $1
 

--- a/src/newrhelic.py
+++ b/src/newrhelic.py
@@ -42,7 +42,7 @@ class NewRHELic:
 
         #store some system info
         self.uname = os.uname()
-
+        self.pid = os.getpid()
         self.hostname = self.uname[1]  #this will likely be Linux-specific, but I don't want to load a whole module to get a hostname another way
         self.kernel = self.uname[2]
         self.arch = self.uname[4]
@@ -341,7 +341,7 @@ class NewRHELic:
         try:
             values = {}
             values['host'] = self.hostname
-            values['pid'] = 1000
+            values['pid'] = self.pid
             values['version'] = self.version
 
             self.json_data['agent'] = values


### PR DESCRIPTION
Files should not be created in /tmp with predictable names.
- Moved PID file to /var/run
- Also added self.pid which is reported to newrelic.
