### PR TITLE
Spec and script changes to allow RHEL5 build

### DIFF
--- a/newrhelic.spec
+++ b/newrhelic.spec
@@ -15,6 +15,8 @@
 %global __python2 %{_bindir}/python%{pybasever}
 
 %{!?python2_sitelib: %define python2_sitelib %(%{__python2} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
+%{!?_initddir: %define _initddir /etc/rc.d/init.d }
+
 
 Summary: RHEL/CentOS monitoring plugin for New Relic
 Name: newrhelic
@@ -81,7 +83,7 @@ rm -rf %{buildroot}
 %defattr(-,root,root,-)
 %config(noreplace) /etc/newrhelic.conf
 %if ! (0%{?rhel} >= 7 || 0%{?fedora} >= 15)
-%config %attr(0755, root, root) ${_initddir}/newrhelic-plugin
+%config %attr(0755, root, root) %{_initddir}/newrhelic-plugin
 %else
 %{_unitdir}/newrhelic.service
 %endif

--- a/newrhelic.spec
+++ b/newrhelic.spec
@@ -7,7 +7,7 @@
 %global __os_install_post %{__python26_os_install_post}
 %else
 %global pyver 2
-%global pybasever 2.6
+%global pybasever 2
 %endif
 
 # Not sure about others

--- a/newrhelic.spec
+++ b/newrhelic.spec
@@ -21,7 +21,7 @@
 Summary: RHEL/CentOS monitoring plugin for New Relic
 Name: newrhelic
 Version: 0.1
-Release: 15%{?dist}
+Release: 16%{?dist}
 Source0: %{name}-%{version}.tar.gz
 #Source0: https://github.com/jduncan-rva/newRHELic/archive/%{name}-%{version}.tar.gz
 #Source0: https://github.com/jduncan-rva/newRHELic/archive/%{release}.tar.gz
@@ -33,6 +33,8 @@ BuildRequires: python-setuptools
 BuildArch: noarch
 Requires: python%{pyver}
 Requires: python-daemon
+Obsoletes: NewRHELic
+Conflicts: NewRHELic
 
 # RHEL 5 has to use python26-psutils
 %if 0%{rhel} == 5
@@ -95,8 +97,11 @@ rm -rf %{buildroot}
 %{_bindir}/newrhelic
 
 %changelog
+* Thu Jun 12 2014 Tommy McNeely <tommy@lark-it.com> 0.1-16
+- Added Obsoletes / Conflicts to replace old name
+
 * Thu Jun 12 2014 Tommy McNeely <tommy@lark-it.com> 0.1-15
-- Fixing all the EL7 vs EL6 vs EL5 issues
+- Fixing all the EL7 vs EL6 vs EL5 issues (EL7 stuff was added by jduncan)
 
 * Thu Jun 12 2014 Tommy McNeely <tommy@lark-it.com> 0.1-14
 - attempts at making the same spec file work for EL5 and EL6

--- a/newrhelic.spec
+++ b/newrhelic.spec
@@ -81,7 +81,7 @@ rm -rf %{buildroot}
 %defattr(-,root,root,-)
 %config(noreplace) /etc/newrhelic.conf
 %if ! (0%{?rhel} >= 7 || 0%{?fedora} >= 15)
-%config %attr(0755, root, root) ${initddir}/newrhelic-plugin
+%config %attr(0755, root, root) ${_initddir}/newrhelic-plugin
 %else
 %{_unitdir}/newrhelic.service
 %endif

--- a/newrhelic.spec
+++ b/newrhelic.spec
@@ -1,3 +1,4 @@
+### SPEC for newrhelic
 
 # EL5 will require python26 from EPEL
 %if 0%{rhel} == 5
@@ -11,9 +12,9 @@
 
 # Not sure about others
 
-%global __python %{_bindir}/python%{pybasever}
+%global __python2 %{_bindir}/python%{pybasever}
 
-%{!?python_sitelib: %define python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
+%{!?python2_sitelib: %define python2_sitelib %(%{__python2} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
 
 Name: newrhelic
 Version: 0.1
@@ -59,11 +60,11 @@ A Red Hat Enterprise Linux-specific monitoring plugin for New Relic.
 %setup -q -n %{name}-%{version}
 
 %build
-%{__python} setup.py build
+%{__python2} setup.py build
 
 %install
 %{__rm} -rf %{buildroot}
-%{__python} setup.py install -O1 --root=$RPM_BUILD_ROOT
+%{__python2} setup.py install -O1 --root=$RPM_BUILD_ROOT
 
 %clean
 rm -rf %{buildroot}

--- a/newrhelic.spec
+++ b/newrhelic.spec
@@ -1,22 +1,40 @@
-%{!?__python2: %global __python2 /usr/bin/python2}
-%global python2_sitelib %(%{__python2} -c "from distutils.sysconfig import get_python_lib; print (get_python_lib())")
 
-Summary: RHEL/CentOS monitoring plugin for New Relic
+# EL5 will require python26 from EPEL
+%if 0%{rhel} == 5
+%global pyver 26
+%global pybasever 2.6
+%global __os_install_post %{__python26_os_install_post}
+%else
+%global pyver 2
+%global pybasever 2.6
+%endif
+
+# Not sure about others
+
+%global __python %{_bindir}/python%{pybasever}
+
+%{!?python_sitelib: %define python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
+
 Name: newrhelic
 Version: 0.1
-Release: 13%{?dist}
-Source0: %{name}-%{version}.tar.gz
-License: GPLv2
-Group: Monitoring
-BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
-BuildRequires: python2-devel
-BuildRequires: python-setuptools
-BuildArch: noarch
-Requires: python-daemon
-Requires: python-psutil
+Release: 14%{?dist}
+Summary: RHEL/CentOS monitoring plugin for New Relic
+
+Group: Applications/System
 Vendor: Jamie Duncan <jduncan@redhat.com>
-Packager: Jamie Duncan <jduncan@redhat.com>
-Url: https://github.com/jduncan-rva/newRHELic
+License: GPLv2
+URL: https://github.com/jduncan-rva/newRHELic
+Source0: %{name}-%{version}.tar.gz
+#Source0: https://github.com/jduncan-rva/newRHELic/archive/%{name}-%{version}.tar.gz
+#Source0: https://github.com/jduncan-rva/newRHELic/archive/%{release}.tar.gz
+BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXXX)
+
+BuildArch: noarch
+BuildRequires: python%{pyver}-devel
+BuildRequires: python-setuptools
+Requires: python%{pyver}
+Requires: python-daemon
+Requires: python%{pyver}-psutil
 
 %description
 A Red Hat Enterprise Linux-specific monitoring plugin for New Relic.
@@ -25,21 +43,29 @@ A Red Hat Enterprise Linux-specific monitoring plugin for New Relic.
 %setup -q -n %{name}-%{version}
 
 %build
-%{__python2} setup.py build
+%{__python} setup.py build
 
 %install
-%{__python2} setup.py install -O1 --root=$RPM_BUILD_ROOT
+%{__rm} -rf %{buildroot}
+%{__python} setup.py install -O1 --root=$RPM_BUILD_ROOT
+
+%clean
+rm -rf %{buildroot}
 
 %files
+%defattr(-,root,root,-)
 %config(noreplace) /etc/newrhelic.conf
 /etc/init.d/newrhelic-plugin
 %dir %{_docdir}/%{name}-%{version}
 %{_docdir}/%{name}-%{version}/*
-%{python2_sitelib}/*egg-info
-%{python2_sitelib}/newrhelic*
+%{python_sitelib}/*egg-info
+%{python_sitelib}/newrhelic*
 %{_bindir}/newrhelic
 
 %changelog
+* Thu Jun 12 2014 Tommy McNeely <tommy@lark-it.com> 0.1-14
+- attempts at making the same spec file work for EL5 and EL6
+
 * Sun Feb 23 2014 Jamie Duncan <jduncan@redhat.com> 0.1-13
 - improvements to spec file. looking to retire setup.cfg soon
 

--- a/newrhelic.spec
+++ b/newrhelic.spec
@@ -21,7 +21,7 @@
 Summary: RHEL/CentOS monitoring plugin for New Relic
 Name: newrhelic
 Version: 0.1
-Release: 14%{?dist}
+Release: 15%{?dist}
 Source0: %{name}-%{version}.tar.gz
 #Source0: https://github.com/jduncan-rva/newRHELic/archive/%{name}-%{version}.tar.gz
 #Source0: https://github.com/jduncan-rva/newRHELic/archive/%{release}.tar.gz
@@ -95,6 +95,9 @@ rm -rf %{buildroot}
 %{_bindir}/newrhelic
 
 %changelog
+* Thu Jun 12 2014 Tommy McNeely <tommy@lark-it.com> 0.1-15
+- Fixing all the EL7 vs EL6 vs EL5 issues
+
 * Thu Jun 12 2014 Tommy McNeely <tommy@lark-it.com> 0.1-14
 - attempts at making the same spec file work for EL5 and EL6
 

--- a/newrhelic.spec
+++ b/newrhelic.spec
@@ -88,8 +88,8 @@ rm -rf %{buildroot}
 
 %dir %{_docdir}/%{name}-%{version}
 %{_docdir}/%{name}-%{version}/*
-%{python_sitelib}/*egg-info
-%{python_sitelib}/newrhelic*
+%{python2_sitelib}/*egg-info
+%{python2_sitelib}/newrhelic*
 %{_bindir}/newrhelic
 
 %changelog

--- a/newrhelic.spec
+++ b/newrhelic.spec
@@ -16,23 +16,19 @@
 
 %{!?python2_sitelib: %define python2_sitelib %(%{__python2} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
 
+Summary: RHEL/CentOS monitoring plugin for New Relic
 Name: newrhelic
 Version: 0.1
 Release: 14%{?dist}
-Summary: RHEL/CentOS monitoring plugin for New Relic
-
-Group: Applications/System
-Vendor: Jamie Duncan <jduncan@redhat.com>
-License: GPLv2
-URL: https://github.com/jduncan-rva/newRHELic
 Source0: %{name}-%{version}.tar.gz
 #Source0: https://github.com/jduncan-rva/newRHELic/archive/%{name}-%{version}.tar.gz
 #Source0: https://github.com/jduncan-rva/newRHELic/archive/%{release}.tar.gz
+License: GPLv2
+Group: Applications/System
 BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXXX)
-
-BuildArch: noarch
 BuildRequires: python%{pyver}-devel
 BuildRequires: python-setuptools
+BuildArch: noarch
 Requires: python%{pyver}
 Requires: python-daemon
 
@@ -43,6 +39,7 @@ Requires: python%{pyver}-psutil
 Requires: python-psutil
 %endif
 
+# RHEL7 and Fedora have different requirements
 %if ! (0%{?rhel} >= 7 || 0%{?fedora} >= 15)
 Requires: chkconfig
 Requires: initscripts
@@ -52,6 +49,10 @@ Requires(post): systemd-units
 %endif
 BuildRequires: systemd-units
 %endif
+
+Vendor: Jamie Duncan <jduncan@redhat.com>
+#Packager: Jamie Duncan <jduncan@redhat.com>
+Url: https://github.com/jduncan-rva/newRHELic
 
 %description
 A Red Hat Enterprise Linux-specific monitoring plugin for New Relic.

--- a/newrhelic.spec
+++ b/newrhelic.spec
@@ -73,7 +73,7 @@ A Red Hat Enterprise Linux-specific monitoring plugin for New Relic.
 rm -rf %{buildroot}
 
 %post
-%if ! (0%{?rhel} >= 7 || 0%{?fedora} >= 15)
+%if (0%{?rhel} >= 7 || 0%{?fedora} >= 15)
 /bin/systemctl enable newrhelic.service
 %else
 /sbin/chkconfig --add newrhelic-plugin
@@ -82,10 +82,10 @@ rm -rf %{buildroot}
 %files
 %defattr(-,root,root,-)
 %config(noreplace) /etc/newrhelic.conf
-%if ! (0%{?rhel} >= 7 || 0%{?fedora} >= 15)
-%config %attr(0755, root, root) %{_initddir}/newrhelic-plugin
-%else
+%if (0%{?rhel} >= 7 || 0%{?fedora} >= 15)
 %{_unitdir}/newrhelic.service
+%else
+%config %attr(0755, root, root) %{_initddir}/newrhelic-plugin
 %endif
 
 %dir %{_docdir}/%{name}-%{version}

--- a/scripts/newrhelic
+++ b/scripts/newrhelic
@@ -37,7 +37,7 @@ except ImportError:
     from daemon import runner
     sys.path.remove('/usr/lib/python2.4/site-packages')
 
-from newrelic import NewRHELic
+from newrhelic import NewRHELic
 
 class RunApp:
     def __init__(self):

--- a/scripts/newrhelic
+++ b/scripts/newrhelic
@@ -29,7 +29,14 @@ import sys
 new_path = os.path.join(os.getcwd(),'NewRHELic/')
 sys.path.append(new_path)
 
-from daemon import runner
+try:
+    from daemon import runner
+except ImportError:
+    # Try loading daemon from 2.4 (EL5)
+    sys.path.append('/usr/lib/python2.4/site-packages')
+    from daemon import runner
+    sys.path.remove('/usr/lib/python2.4/site-packages')
+
 from newrelic import NewRHELic
 
 class RunApp:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ data_files=[
 if on_fedora:
     data_files.append(('/usr/lib/systemd/system', ['scripts/newrhelic.service']))
 else:
-    data_files.append(('/etc/init.d', ['scripts/newrhelic-plugin']))
+    data_files.append(('/etc/rc.d/init.d', ['scripts/newrhelic-plugin']))
  
 setup(
     name=name,

--- a/src/newrhelic.py
+++ b/src/newrhelic.py
@@ -53,13 +53,6 @@ class NewRHELic:
 
         self.first_run = True   #this is set to False after the first run function is called
 
-
-        self.on_fedora = False
-        distro_test = open('/etc/redhat-release','r')
-        d_version = distro_test[0].split()[0]
-        if d_version = 'Fedora':    #we're using Fedora, psutil is a different here.
-            self.on_fedora = True
-
 	#Various IO buffers
         self.buffers = {
             'bytes_sent': 0,
@@ -182,7 +175,7 @@ class NewRHELic:
     def _get_net_stats(self):
         '''This will form network IO stats for the entire system'''
         try:
-            if self.on_fedora:
+            if callable(psutil.net_io_counters):
                 io = psutil.net_io_counters()
             else:
                 io = psutil.network_io_counters()
@@ -432,7 +425,7 @@ class NewRHELic:
         '''this will prime the needed buffers to present valid data when math is needed'''
         try:
             #create the first counter values to do math against for network, disk and swap
-            if self.on_fedora:
+            if callable(psutil.net_io_counters):
                 net_io = psutil.net_io_counters()
             else:
                 net_io = psutil.network_io_counters()

--- a/src/newrhelic.py
+++ b/src/newrhelic.py
@@ -175,9 +175,9 @@ class NewRHELic:
     def _get_net_stats(self):
         '''This will form network IO stats for the entire system'''
         try:
-            if callable(psutil.net_io_counters):
+            try:
                 io = psutil.net_io_counters()
-            else:
+            except AttributeError:
                 io = psutil.network_io_counters()
 
             for i in range(len(io)):
@@ -425,9 +425,9 @@ class NewRHELic:
         '''this will prime the needed buffers to present valid data when math is needed'''
         try:
             #create the first counter values to do math against for network, disk and swap
-            if callable(psutil.net_io_counters):
+            try:
                 net_io = psutil.net_io_counters()
-            else:
+            except AttributeError:
                 net_io = psutil.network_io_counters()
             for i in range(len(net_io)):
                 self.buffers[net_io._fields[i]] = net_io[i]


### PR DESCRIPTION
NOTE: this also has a fix for `scripts/newrhelic` related to the rename

I added an if statement towards the top, and made it look similar to
other python26 modules.

I also cleaned up some lint errors, the only lint error right now is
for the URL on Source0. We probably need to think about semantic
versioning, and maybe upload the source file with the proper name?

Also workaround for loading daemon from python2.4 in RHEL5.

~tommy
