### PR TITLE
Fix for Issue #6 - Bad File Descriptor

### DIFF
--- a/scripts/newrhelic
+++ b/scripts/newrhelic
@@ -47,12 +47,32 @@ class RunApp:
         self.stderr_path = '/dev/tty'
         self.pidfile_path =  '/var/run/newrhelic.pid'
         self.pidfile_timeout = 5
+        self.files_preserve = self.getLogFileHandles(self.data.logger)
+
+    def getLogFileHandles(self,logger):
+        """ Get a list of filehandle numbers from logger
+            to be handed to DaemonContext.files_preserve
+        """
+        handles = []
+        for handler in logger.handlers:
+            handles.append(handler.stream.fileno())
+        if logger.parent:
+            handles += self.getLogFileHandles(logger.parent)
+        return handles
 
     def run(self):
         while True:
             self.data.add_to_newrelic()
             time.sleep(60)
 
+class NewRHELicDaemonRunner(runner.DaemonRunner):
+    """ Extend the basic DaemonRunnner with file_preserve """
+    def __init__(self, app):
+        super(NewRHELicDaemonRunner, self).__init__(app)
+        app.data.logger.warning('Our Special Runner')
+        self.daemon_context.files_preserve = app.files_preserve
+
+
 app = RunApp()
-daemon_runner = runner.DaemonRunner(app)
+daemon_runner = NewRHELicDaemonRunner(app)
 daemon_runner.do_action()


### PR DESCRIPTION
This fixes the errors on "stopping" (and starting if the log level
is set low enough). It gets a list of file descriptors from logger
and passes them to DaemonContext through a new extension to "runner"

~tommy
