### PR TITLE
Fix for Issue #17 - moving data out of config

### DIFF
--- a/conf/newrhelic.conf
+++ b/conf/newrhelic.conf
@@ -1,7 +1,6 @@
 [site]
 
 key = <your license key for new relic> 
-url = https://platform-api.newrelic.com/platform/v1/metrics
 
 [proxy]
 enable_proxy = False
@@ -11,13 +10,10 @@ proxy_port = 3128
 
 [plugin]
 
-name = OS Statistics
-guid = com.rhel.os_statistics
-duration = 60
-version = 0.1
-
-logfile = /var/log/newrhelic.log
+interval = 60
 loglevel = INFO
+logfile = /var/log/newrhelic.log
+pidfile = /var/run/newrhelic.pid
 
 enable_all = True
 enable_disk = False

--- a/scripts/newrhelic
+++ b/scripts/newrhelic
@@ -45,7 +45,7 @@ class RunApp:
         self.stdin_path = '/dev/null'
         self.stdout_path = '/dev/tty'
         self.stderr_path = '/dev/tty'
-        self.pidfile_path =  '/var/run/newrhelic.pid'
+        self.pidfile_path =  self.data.pid_file
         self.pidfile_timeout = 5
         self.files_preserve = self.getLogFileHandles(self.data.logger)
 
@@ -63,13 +63,12 @@ class RunApp:
     def run(self):
         while True:
             self.data.add_to_newrelic()
-            time.sleep(60)
+            time.sleep(self.data.interval)
 
 class NewRHELicDaemonRunner(runner.DaemonRunner):
     """ Extend the basic DaemonRunnner with file_preserve """
     def __init__(self, app):
         super(NewRHELicDaemonRunner, self).__init__(app)
-        app.data.logger.warning('Our Special Runner')
         self.daemon_context.files_preserve = app.files_preserve
 
 

--- a/src/newrhelic.py
+++ b/src/newrhelic.py
@@ -37,6 +37,10 @@ class NewRHELic:
 
     def __init__(self, debug=False, conf='/etc/newrhelic.conf'):
 
+        self.guid = 'com.rhel.os_statistics'
+        self.name = 'OS Statistics'
+        self.version = '0.2.0'
+        self.api_url = 'https://platform-api.newrelic.com/platform/v1/metrics'
         self.config_file = conf
         socket.setdefaulttimeout(5)
 
@@ -103,11 +107,8 @@ class NewRHELic:
 
         try:
             self.license_key = config.get('site', 'key')
-            self.api_url = config.get('site', 'url')
-            self.duration = config.getint('plugin', 'duration')
-            self.guid = config.get('plugin', 'guid')
-            self.name = config.get('plugin', 'name')
-            self.version = config.get('plugin','version')
+            self.pid_file = config.get('plugin', 'pidfile')
+            self.interval = config.getint('plugin', 'interval')
             self.enable_proxy = config.getboolean('proxy','enable_proxy')
 
             if self.enable_proxy:
@@ -392,7 +393,7 @@ class NewRHELic:
             c_dict = {}
             c_dict['name'] = self.hostname
             c_dict['guid'] = self.guid
-            c_dict['duration'] = self.duration
+            c_dict['duration'] = self.interval
 
             #always get the sys information
             self._get_sys_info()


### PR DESCRIPTION
- Moved the following from the config file to the **init**
  *\* api_url
  *\* guid
  *\* name
  *\* version
- Renamed duration -> interval (since I think it makes more sense
- Added pidfile to config
- Updated "script" to use pidfile and duration
- bumped version from '0.1' to '0.2.0' (symatic versioning)
